### PR TITLE
Fix handling of conditioning masks

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -44,15 +44,15 @@ def slice_cond(tile_h, tile_h_len, tile_w, tile_w_len, cond, area):
             new_w = max(0, w - tile_w)
             new_h_end = min(tile_h_end, h_end - tile_h)
             new_w_end = min(tile_w_end, w_end - tile_w)
-            cond[1]['area'] = (new_h_end - new_h, new_w_end - new_w, new_h, new_w)
+            cond['area'] = (new_h_end - new_h, new_w_end - new_w, new_h, new_w)
         else:
             return (cond, True)
     if mask is not None:
         new_mask = tiling.get_slice(mask, tile_h,tile_h_len,tile_w,tile_w_len)
-        if new_mask.sum().cpu() == 0.0 and 'mask' in cond[1]:
+        if new_mask.sum().cpu() == 0.0 and 'mask' in cond:
             return (cond, True)
         else:
-            cond[1]['mask'] = new_mask
+            cond['mask'] = new_mask
     return (cond, False)
 
 def slice_gligen(tile_h, tile_h_len, tile_w, tile_w_len, cond, gligen):
@@ -94,6 +94,14 @@ def slices_T2I(h, h_len, w, w_len, model:comfy.controlnet.ControlBase, img):
     if img is None:
         img = model.cond_hint_original
     model.cond_hint = tiling.get_slice(img, h*8, h_len*8, w*8, w_len*8).float().to(model.device)
+
+def scale_mask(mask_tensor, shape, device):
+    """ensures noise mask is of proper dimensions"""
+    mask_tensor = torch.nn.functional.interpolate(mask_tensor.reshape((-1, 1, mask_tensor.shape[-2], mask_tensor.shape[-1])), size=(shape[2], shape[3]), mode="bilinear")
+    mask_tensor = mask_tensor.squeeze(1) # Remove extra dimension added during reshape.
+    mask_tensor = comfy.utils.repeat_to_batch_size(mask_tensor, shape[0])
+    mask_tensor = mask_tensor.to(device)
+    return mask_tensor
 
 # TODO: refactor some of the mess
 
@@ -166,12 +174,12 @@ def sample_common(model, add_noise, noise_seed, tile_width, tile_height, tiling_
     #cond area and mask
     spatial_conds_pos = [
         (c[1]['area'] if 'area' in c[1] else None, 
-            comfy.sample.prepare_mask(c[1]['mask'], shape, device) if 'mask' in c[1] else None)
+            scale_mask(c[1]['mask'], shape, device) if 'mask' in c[1] else None)
         for c in positive
     ]
     spatial_conds_neg = [
         (c[1]['area'] if 'area' in c[1] else None, 
-            comfy.sample.prepare_mask(c[1]['mask'], shape, device) if 'mask' in c[1] else None)
+            scale_mask(c[1]['mask'], shape, device) if 'mask' in c[1] else None)
         for c in negative
     ]
 


### PR DESCRIPTION
Allow me to preface: I don't know a thing about PyTorch, Diffusion, Arrays, Tensors, or any of this nonsense. I'm just a girl who wants to mask and tile. 😷

First problem. In `slice_cond` the branches that handle areas expect cond to be a tuple. _cond is not a tuple_. Removed the indexing which clears the error in #36 

Second problem, the tensor is not the size the sampler expects it to be later on in the process. I did a lots of debugger and eventually glazed that mask tensors are 3-dimensional with no color information, while other tensors are 4-dimensional. But some functions here are turning a nice mask tensor into a full-color tensor.

See, `comfy.sample.prepare_mask` fluffs up the tensor from a typical mask tensor of `mask X x-pos X y-pos` to a `mask X rgba X x-pos X y-pos` size. Not a problem for a while until it is. 

So I lifted that function and did a little squeeze to remove the baby dimension that gets injected when the reshape interpolates the tensor into the size which `interpolate` can handle (for whatever reason it requires a 4-dimensional array or it dies (pytorch is a dumpster fire of raccoons who are also on fire)).

Is this correct? I don't know. Is it right? Who knows. Does it stop the crashes when your _condies have maskeys_? Yes. It stops those.

Someone with maths please just take this PR and make it beautiful. And write some tests.

Also I don't know squat about Python.